### PR TITLE
Second separator for Force Quit App item

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -100,6 +100,7 @@ var MenuButton = GObject.registerClass(class FedoraMenu_MenuButton extends Panel
 		this.item3 = new PopupMenu.PopupSeparatorMenuItem()
 		this.item4 = new PopupMenu.PopupMenuItem(_('Software Center'))
 		this.item5 = new PopupMenu.PopupMenuItem(_('Activities'))
+		this.item7 = new PopupMenu.PopupSeparatorMenuItem()
 		this.item6 = new PopupMenu.PopupMenuItem(_('Force Quit App'))
 		this.item7 = new PopupMenu.PopupSeparatorMenuItem()
 		this.item8 = new PopupMenu.PopupMenuItem(_('Terminal'))


### PR DESCRIPTION
The Force Quit App item is too easy to accidentally click while trying to click on Activities item. Needs another separator above it.